### PR TITLE
Update to use motebehov v4 endpoint

### DIFF
--- a/src/api/motebehovRoutes.ts
+++ b/src/api/motebehovRoutes.ts
@@ -18,7 +18,7 @@ function motebehovRoutes(tokenDings: Auth) {
   router.get(
     "/api/motebehov",
     proxyTokenXCall(
-      `${config.SYFOMOTEBEHOV_HOST}/syfomotebehov/api/v3/arbeidstaker/motebehov/all`,
+      `${config.SYFOMOTEBEHOV_HOST}/syfomotebehov/api/v4/arbeidstaker/motebehov`,
       getTokenXHeaders,
     ),
   );

--- a/test/motebehov.test.ts
+++ b/test/motebehov.test.ts
@@ -24,7 +24,7 @@ describe("motebehov routes", () => {
 
     const proxyServer = express();
     proxyServer.get(
-      "/syfomotebehov/api/v3/arbeidstaker/motebehov/all",
+      "/syfomotebehov/api/v4/arbeidstaker/motebehov",
       (req, res) => {
         if (req.header("Authorization") === "Bearer tokenX-123") {
           res.status(200).send("ok");


### PR DESCRIPTION
### Migrasjonsplan for å bruke v4 motebehov-endepunkt i esyfo-proxy og dialogmote-mikrofrontend:
1. Først endre navn på v4-felt i syfomotebehov fra motebehovWithFormValues til motebehov https://github.com/navikt/syfomotebehov/pull/504
2. Etter det er det ikke noe endringer mellom v3 og v4 DTOene som dialogmote-mikrofrontend bryr seg om, så da kan denne rute-endringen rulles ut.

### Tidligere utdatert plan:
1. Endre dialogmote-mikrofrontend til å støtte begge formater (https://github.com/navikt/dialogmote-mikrofrontend/pull/1000)
3. Endre esyfo-proxy til å gå over til å rute til v4-endepunkt (denne PR)
4. Endre dialogmote-mikrofrontend til å kun støtte v4-endepunkt
5. (Fjerne v3-endepunkter i syfomotebehov)